### PR TITLE
convert header dropdowns from links to buttons

### DIFF
--- a/assets/scss/drop-down.scss
+++ b/assets/scss/drop-down.scss
@@ -9,7 +9,7 @@
     border-radius: $header-hover-radius;
   }
 
-  .fa-chevron-down {
+  .dropdown-trigger-icon {
     font-size: 0.8rem;
     color: $opennem-link-color;
     position: relative;
@@ -17,8 +17,11 @@
   }
 
   .dropdown-trigger {
+    background-color: transparent;
+    height: 2.25rem;
     font-family: $header-font-family;
     font-weight: 700;
+    font-size: inherit;
     margin-right: $app-padding / 2;
     padding: $app-padding / 8 $app-padding / 2;
     color: #000;

--- a/components/ui/RegionDropdown.vue
+++ b/components/ui/RegionDropdown.vue
@@ -2,15 +2,17 @@
   <div
     :class="{'is-active': dropdownActive}"
     class="dropdown">
-    <a
+    <button
       v-on-clickaway="handleClickAway"
-      class="dropdown-trigger"
+      class="dropdown-trigger button inverted"
       @click="handleClick">
       <span>
         <strong>{{ regionLabel }}</strong>
-        <i class="fal fa-chevron-down" />
+        <i
+          :class="['fal dropdown-trigger-icon', dropdownActive ? 'fa-chevron-up' : 'fa-chevron-down']"
+        />
       </span>
-    </a>
+    </button>
 
     <transition name="slide-down-fade">
       <div

--- a/components/ui/ViewDropdown.vue
+++ b/components/ui/ViewDropdown.vue
@@ -2,16 +2,18 @@
   <div
     :class="{ 'is-active': dropdownActive }"
     class="dropdown">
-    <a
+    <button
       v-on-clickaway="handleClickAway"
-      class="dropdown-trigger"
+      class="dropdown-trigger button inverted"
       @click="handleClick"
     >
       <span>
         <strong>{{ viewLabel }}</strong>
-        <i class="fal fa-chevron-down" />
+        <i
+          :class="['fal dropdown-trigger-icon', dropdownActive ? 'fa-chevron-up' : 'fa-chevron-down']"
+        />
       </span>
-    </a>
+    </button>
 
     <transition name="slide-down-fade">
       <div


### PR DESCRIPTION
- buttons better reflect the purpose to screen readers instead of using `a` link)
- button (bulma) will have default hover and focus styles
- button can be focused (depending on browser/device), whereas links are more likely to be skipped, also buttons can be activated with `space` instead of moving the screen down (as an a tag without a href will 'jump' the screen down).
- add dynamic chevrons (down/up) when expanded or collapsed

**Screenshot - Before (top), After (bottom)**
<img width="741" alt="Screen Shot 2021-11-28 at 9 02 09 pm" src="https://user-images.githubusercontent.com/1396140/143765146-77aa2721-af4e-4f80-832c-6359c2312acb.png">


