### PR TITLE
Use DOI link and clarify used category

### DIFF
--- a/components/layout/AppFooter.vue
+++ b/components/layout/AppFooter.vue
@@ -42,8 +42,8 @@
         <div v-show="isEmissionsWorldRegion">
           <a
             target="_blank"
-            href="https://zenodo.org/record/5494497#.YXod3NlBz0p"
-            title="Link to dataset used by this visualisation">PRIMAP-hist (HISTCR; Kyoto GHG (AR4); Total)</a>,
+            href="https://doi.org/10.5281/zenodo.5494497"
+            title="Link to dataset used by this visualisation">PRIMAP-hist (HISTCR; Kyoto GHG (AR4); Total excl. Landuse)</a>,
         </div>
         
         <div 


### PR DESCRIPTION
Following up on a Twitter discussion with Tim, i'd propose to include the used category with a bit more detail in the footer.

https://twitter.com/openclimatedata/status/1481917177804595210

I also changed the link to use the DOI link, which should always point to the landing page of the dataset.